### PR TITLE
Support for a custom label

### DIFF
--- a/src/JsonInput.tsx
+++ b/src/JsonInput.tsx
@@ -8,6 +8,7 @@ import ReactJson, {
 
 type Props = {
   source: string;
+  label: string;
   helperText?: string;
   jsonString?: boolean;
   reactJsonOptions?: Omit<ReactJsonViewProps, "src">;
@@ -20,7 +21,7 @@ export const JsonInput: React.FC<Props> = (props) => {
     isRequired,
   } = useInput(props);
 
-  const { source, helperText, jsonString = false, reactJsonOptions } = props;
+  const { source, label, helperText, jsonString = false, reactJsonOptions } = props;
 
   function change(updatedSrc: any) {
     let updatedValue = updatedSrc;
@@ -67,7 +68,7 @@ export const JsonInput: React.FC<Props> = (props) => {
 
   return (
     <div>
-      <Labeled source={source} isRequired={isRequired}>
+      <Labeled source={source} label={label} isRequired={isRequired}>
         <ReactJson
           {...reactJsonOptions}
           src={src || {}}


### PR DESCRIPTION
Currently it uses `source` as a label and can't be changed. And with this change, we can customize the label.